### PR TITLE
DOC simplify examples + use get_objective

### DIFF
--- a/objective.py
+++ b/objective.py
@@ -9,20 +9,25 @@ with safe_import_context() as import_ctx:
 class Objective(BaseObjective):
     name = "Ordinary Least Squares"
 
-    # All parameters 'p' defined here are available as 'self.p'
+    # All parameters 'p' defined here are available as 'self.p'.
+    # This means OLS objective will have a parameter `self.whitten_y`.
     parameters = {
-        'fit_intercept': [False],
+        'whitten_y': [False, True],
     }
 
-    def get_one_solution(self):
-        # Return one solution. This should be compatible with 'self.compute'.
-        return np.zeros(self.X.shape[1])
+    # Minimal version of benchopt required to run this benchmark.
+    # Bump it up if the benchmark depends on a new feature of benchopt.
+    min_benchopt_version = "1.2.1"
 
     def set_data(self, X, y):
         # The keyword arguments of this function are the keys of the `data`
         # dict in the `get_data` function of the dataset.
         # They are customizable.
         self.X, self.y = X, y
+
+        # if whitten_y, remove the mean of `y`.
+        if self.whitten_y:
+            y -= y.mean(axis=0)
 
     def compute(self, beta):
         # The arguments of this function are the outputs of the
@@ -31,8 +36,12 @@ class Objective(BaseObjective):
         diff = self.y - self.X.dot(beta)
         return .5 * diff.dot(diff)
 
-    def to_dict(self):
+    def get_one_solution(self):
+        # Return one solution. This should be compatible with 'self.compute'.
+        return np.zeros(self.X.shape[1])
+
+    def get_objective(self):
         # The output of this function are the keyword arguments
         # for the `set_objective` method of the solver.
         # They are customizable.
-        return dict(X=self.X, y=self.y, fit_intercept=self.fit_intercept)
+        return dict(X=self.X, y=self.y)

--- a/objective.py
+++ b/objective.py
@@ -10,9 +10,9 @@ class Objective(BaseObjective):
     name = "Ordinary Least Squares"
 
     # All parameters 'p' defined here are available as 'self.p'.
-    # This means OLS objective will have a parameter `self.whitten_y`.
+    # This means the OLS objective will have a parameter `self.whiten_y`.
     parameters = {
-        'whitten_y': [False, True],
+        'whiten_y': [False, True],
     }
 
     # Minimal version of benchopt required to run this benchmark.
@@ -25,8 +25,8 @@ class Objective(BaseObjective):
         # They are customizable.
         self.X, self.y = X, y
 
-        # if whitten_y, remove the mean of `y`.
-        if self.whitten_y:
+        # if whiten_y is True, remove the mean of `y`.
+        if self.whiten_y:
             y -= y.mean(axis=0)
 
     def compute(self, beta):

--- a/solvers/python-gd.py
+++ b/solvers/python-gd.py
@@ -9,31 +9,24 @@ class Solver(BaseSolver):
     name = 'GD'
 
     # any parameter defined here is accessible as a class attribute
-    parameters = {'use_acceleration': [False, True]}
+    parameters = {'scale_step': [1, 2]}
 
-    def set_objective(self, X, y, fit_intercept=False):
+    def set_objective(self, X, y):
         # The arguments of this function are the results of the
-        # `to_dict` method of the objective.
+        # `get_objective` method of the objective.
         # They are customizable.
         self.X, self.y = X, y
-        self.fit_intercept = fit_intercept
 
     def run(self, n_iter):
+        # This is the function that is called to evaluate the solver.
+        # It runs the algorithm for a given a number of iterations `n_iter`.
+
         L = np.linalg.norm(self.X, ord=2) ** 2
-        n_features = self.X.shape[1]
-        w = np.zeros(n_features)
-        w_acc = np.zeros(n_features)
-        w_old = np.zeros(n_features)
-        t_new = 1
+        alpha = self.scale_step / L
+        w = np.zeros(self.X.shape[1])
         for _ in range(n_iter):
-            if self.use_acceleration:
-                t_old = t_new
-                t_new = (1 + np.sqrt(1 + 4 * t_old ** 2)) / 2
-                w_old[:] = w  # x in Beck & Teboulle (2009) notation
-                w[:] = w_acc  # y in Beck & Teboulle (2009) notation
-            w -= self.X.T.dot(self.X.dot(w) - self.y) / L
-            if self.use_acceleration:
-                w_acc[:] = w + (t_old - 1.) / t_new * (w - w_old)
+            w -= alpha * self.X.T.dot(self.X.dot(w) - self.y)
+
         self.w = w
 
     def get_result(self):

--- a/solvers/python-gd.py
+++ b/solvers/python-gd.py
@@ -9,7 +9,7 @@ class Solver(BaseSolver):
     name = 'GD'
 
     # any parameter defined here is accessible as a class attribute
-    parameters = {'scale_step': [1, 2]}
+    parameters = {'scale_step': [1, 1.99]}
 
     def set_objective(self, X, y):
         # The arguments of this function are the results of the


### PR DESCRIPTION
Simplify the example and use the newest API:

- remove unused `fit_intercept` and replace it with a `whitten_y`.
- remove complex `use_acceleration` and replace it with a scaling of the learning rate.
- Use `get_objective` instead of `to_dict`, adapting to benchopt/benchopt#489