### PR TITLE
Reducing the number of jobs in the CI, only running the last commit

### DIFF
--- a/.github/workflows/lint_benchmarks.yml
+++ b/.github/workflows/lint_benchmarks.yml
@@ -1,10 +1,12 @@
 name: Lint
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
-  cancel-in-progress: true
 
 on:
-    workflow_call:
+  # Cancel in-progress workflows when pushing
+  # a new commit on the same branch
+  concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+  workflow_call:
 
 
 jobs:

--- a/.github/workflows/lint_benchmarks.yml
+++ b/.github/workflows/lint_benchmarks.yml
@@ -1,4 +1,7 @@
 name: Lint
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
+  cancel-in-progress: true
 
 on:
     workflow_call:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,11 @@
 name: Tests
 
 on:
+  # Cancel in-progress workflows when pushing
+  # a new commit on the same branch
+  concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
   push:
     branches:
       - main

--- a/.github/workflows/test_benchmarks.yml
+++ b/.github/workflows/test_benchmarks.yml
@@ -1,4 +1,7 @@
 name: Test Benchmark
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
+  cancel-in-progress: true
 
 on:
   workflow_call:

--- a/.github/workflows/test_benchmarks.yml
+++ b/.github/workflows/test_benchmarks.yml
@@ -1,9 +1,11 @@
 name: Test Benchmark
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
-  cancel-in-progress: true
 
 on:
+  # Cancel in-progress workflows when pushing
+  # a new commit on the same branch
+  concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
   workflow_call:
     inputs:
       benchopt_branch:


### PR DESCRIPTION
In a PR, each push executes continuous integration tests; however, if you commit and push multiple times within a PR, you create a queue of jobs and testing.

If you have tests that take longer, this ends up generating a long queue to have one test done. This is meaningless, as we always want to test only the last commit.

In this PR, we ensure that CI stops the tests for the previous push and runs the test only for the last one.
