### PR TITLE
Adding libomp install

### DIFF
--- a/.github/workflows/test_benchmarks.yml
+++ b/.github/workflows/test_benchmarks.yml
@@ -65,7 +65,10 @@ jobs:
 
     - name: Install libomp (macOS only)
       if: matrix.os == 'macos-latest'
-      run: arch -x86_64 /usr/local/homebrew/bin/brew install libomp
+      run: |
+        arch -x86_64 /usr/local/homebrew/bin/brew install libomp
+        echo 'export DYLD_LIBRARY_PATH="/usr/local/opt/libomp/lib:$DYLD_LIBRARY_PATH"' >> $GITHUB_ENV
+
 
     - name: Set up environment variables for llvm (macOS only)
       if: matrix.os == 'macos-latest'

--- a/.github/workflows/test_benchmarks.yml
+++ b/.github/workflows/test_benchmarks.yml
@@ -68,6 +68,8 @@ jobs:
       run: |
         arch -x86_64 /usr/local/homebrew/bin/brew install libomp
         echo 'export DYLD_LIBRARY_PATH="/usr/local/opt/libomp/lib:$DYLD_LIBRARY_PATH"' >> $GITHUB_ENV
+        echo 'export LDFLAGS="-L/usr/local/opt/libomp/lib"' >> $GITHUB_ENV
+        echo 'export CPPFLAGS="-I/usr/local/opt/libomp/include"' >> $GITHUB_ENV
 
 
     - name: Set up environment variables for llvm (macOS only)

--- a/.github/workflows/test_benchmarks.yml
+++ b/.github/workflows/test_benchmarks.yml
@@ -69,10 +69,16 @@ jobs:
     - name: Install libomp on macOS
       if: matrix.os == 'macos-latest'
       run: |
-        brew install libomp
+        # Install libomp from source for arm64 architecture
+        brew uninstall libomp  # Uninstall if already installed to ensure arm64 version is used
+        brew install libomp --build-from-source
+
+        # Set environment variables for libomp
         echo 'export LDFLAGS="-L/opt/homebrew/opt/libomp/lib"' >> $GITHUB_ENV
         echo 'export CPPFLAGS="-I/opt/homebrew/opt/libomp/include"' >> $GITHUB_ENV
         echo 'export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:/opt/homebrew/opt/libomp/lib' >> $GITHUB_ENV
+
+        # Create necessary symlink (adjust path as needed)
         sudo mkdir -p /usr/local/opt/libomp/lib
         sudo ln -s /opt/homebrew/opt/libomp/lib/libomp.dylib /usr/local/opt/libomp/lib/libomp.dylib
 

--- a/.github/workflows/test_benchmarks.yml
+++ b/.github/workflows/test_benchmarks.yml
@@ -74,7 +74,7 @@ jobs:
         echo 'export LDFLAGS="-L/opt/homebrew/opt/llvm/lib"' >> $GITHUB_ENV
         echo 'export CPPFLAGS="-I/opt/homebrew/opt/llvm/include"' >> $GITHUB_ENV
         sudo mkdir -p /usr/local/opt/libomp/lib
-        ln -s /opt/homebrew/opt/llvm/lib/libomp.dylib /usr/local/opt/libomp/lib/libomp.dylib
+        sudo ln -s /opt/homebrew/opt/llvm/lib/libomp.dylib /usr/local/opt/libomp/lib/libomp.dylib
 
     - name: Install benchopt and its dependencies
       run: |

--- a/.github/workflows/test_benchmarks.yml
+++ b/.github/workflows/test_benchmarks.yml
@@ -66,24 +66,6 @@ jobs:
 
     - run: conda info
 
-    - name: Setup Rosetta (macOS only)
-      if: matrix.os == 'macos-latest'
-      run: sudo softwareupdate --install-rosetta --agree-to-license
-
-    - name: Install Homebrew (macOS only)
-      if: matrix.os == 'macos-latest'
-      run: arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-
-    - name: Setup Homebrew environment (macOS only)
-      if: matrix.os == 'macos-latest'
-      run: |
-        echo 'eval "$(/usr/local/bin/brew shellenv)"' >> $HOME/.profile
-        eval "$(/usr/local/bin/brew shellenv)"
-
-    - name: Install libomp (macOS only)
-      if: matrix.os == 'macos-latest'
-      run: arch -x86_64 /usr/local/bin/brew install libomp
-
     - name: Add libomp to path on macOS
       if: matrix.os == 'macos-latest'
       run: |

--- a/.github/workflows/test_benchmarks.yml
+++ b/.github/workflows/test_benchmarks.yml
@@ -73,7 +73,7 @@ jobs:
         brew install llvm
         echo 'export LDFLAGS="-L/opt/homebrew/opt/llvm/lib"' >> $GITHUB_ENV
         echo 'export CPPFLAGS="-I/opt/homebrew/opt/llvm/include"' >> $GITHUB_ENV
-        mkdir -p /usr/local/opt/libomp/lib
+        sudo mkdir -p /usr/local/opt/libomp/lib
         ln -s /opt/homebrew/opt/llvm/lib/libomp.dylib /usr/local/opt/libomp/lib/libomp.dylib
 
     - name: Install benchopt and its dependencies

--- a/.github/workflows/test_benchmarks.yml
+++ b/.github/workflows/test_benchmarks.yml
@@ -54,6 +54,28 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+
+    - name: Setup Rosetta (macOS only)
+      if: matrix.os == 'macos-latest'
+      run: sudo softwareupdate --install-rosetta --agree-to-license
+
+    - name: Install Homebrew (macOS only)
+      if: matrix.os == 'macos-latest'
+      run: arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+    - name: Install libomp (macOS only)
+      if: matrix.os == 'macos-latest'
+      run: arch -x86_64 /usr/local/homebrew/bin/brew install libomp
+
+    - name: Set up environment variables for llvm (macOS only)
+      if: matrix.os == 'macos-latest'
+      run: |
+        echo 'export PATH="/opt/homebrew/opt/llvm/bin:$PATH"' >> $GITHUB_ENV
+        echo 'export LDFLAGS="-L/opt/homebrew/opt/llvm/lib"' >> $GITHUB_ENV
+        echo 'export CPPFLAGS="-I/opt/homebrew/opt/llvm/include"' >> $GITHUB_ENV
+        echo 'export LDFLAGS="-L/opt/homebrew/opt/llvm/lib/c++ -Wl,-rpath,/opt/homebrew/opt/llvm/lib/c++"' >> $GITHUB_ENV
+        source $GITHUB_ENV
+
     - name: Setup Conda
       uses: conda-incubator/setup-miniconda@v2
       with:
@@ -65,16 +87,6 @@ jobs:
         activate-environment: ${{ env.CONDA_ENV }}
 
     - run: conda info
-
-    - name: Install libomp on macOS
-      if: matrix.os == 'macos-latest'
-      run: |
-        brew update
-        brew install llvm
-        echo 'export LDFLAGS="-L/opt/homebrew/opt/llvm/lib"' >> $GITHUB_ENV
-        echo 'export CPPFLAGS="-I/opt/homebrew/opt/llvm/include"' >> $GITHUB_ENV
-        sudo mkdir -p /usr/local/opt/libomp/lib
-        sudo ln -s /opt/homebrew/opt/llvm/lib/libomp.dylib /usr/local/opt/libomp/lib/libomp.dylib
 
     - name: Install benchopt and its dependencies
       run: |

--- a/.github/workflows/test_benchmarks.yml
+++ b/.github/workflows/test_benchmarks.yml
@@ -55,31 +55,36 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Setup Rosetta (macOS only)
-      if: matrix.os == 'macos-latest'
-      run: sudo softwareupdate --install-rosetta --agree-to-license
-
     - name: Install Homebrew (macOS only)
       if: matrix.os == 'macos-latest'
       run: arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+    - name: Set up Homebrew environment (macOS only)
+      if: matrix.os == 'macos-latest'
+      run: |
+        echo 'eval "$(/usr/local/bin/brew shellenv)"' >> /Users/runner/.bash_profile
+        eval "$(/usr/local/bin/brew shellenv)"
+        echo 'export PATH="/usr/local/opt/libomp/bin:$PATH"' >> $GITHUB_ENV
+        echo 'export LDFLAGS="-L/usr/local/opt/libomp/lib"' >> $GITHUB_ENV
+        echo 'export CPPFLAGS="-I/usr/local/opt/libomp/include"' >> $GITHUB_ENV
 
     - name: Install libomp (macOS only)
       if: matrix.os == 'macos-latest'
       run: |
         arch -x86_64 /usr/local/homebrew/bin/brew install libomp
         echo 'export DYLD_LIBRARY_PATH="/usr/local/opt/libomp/lib:$DYLD_LIBRARY_PATH"' >> $GITHUB_ENV
-        echo 'export LDFLAGS="-L/usr/local/opt/libomp/lib"' >> $GITHUB_ENV
-        echo 'export CPPFLAGS="-I/usr/local/opt/libomp/include"' >> $GITHUB_ENV
 
 
     - name: Set up environment variables for llvm (macOS only)
       if: matrix.os == 'macos-latest'
       run: |
         echo 'export PATH="/opt/homebrew/opt/llvm/bin:$PATH"' >> $GITHUB_ENV
-        echo 'export LDFLAGS="-L/opt/homebrew/opt/llvm/lib"' >> $GITHUB_ENV
-        echo 'export CPPFLAGS="-I/opt/homebrew/opt/llvm/include"' >> $GITHUB_ENV
-        echo 'export LDFLAGS="-L/opt/homebrew/opt/llvm/lib/c++ -Wl,-rpath,/opt/homebrew/opt/llvm/lib/c++"' >> $GITHUB_ENV
-        source $GITHUB_ENV
+        echo 'export LDFLAGS="-L/opt/homebrew/opt/llvm/lib -L/usr/local/opt/libomp/lib -L/opt/homebrew/opt/llvm/lib/c++ -Wl,-rpath,/opt/homebrew/opt/llvm/lib/c++"' >> $GITHUB_ENV
+        echo 'export CPPFLAGS="-I/opt/homebrew/opt/llvm/include -I/usr/local/opt/libomp/include"' >> $GITHUB_ENV
+
+    - name: Source environment variables (macOS only)
+      if: matrix.os == 'macos-latest'
+      run: source $GITHUB_ENV
 
     - name: Setup Conda
       uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/test_benchmarks.yml
+++ b/.github/workflows/test_benchmarks.yml
@@ -66,6 +66,12 @@ jobs:
 
     - run: conda info
 
+    - name: Install libomp on macOS
+      if: matrix.os == 'macos-latest'
+      run: |
+        brew install libomp
+        echo 'export DYLD_LIBRARY_PATH=/usr/local/opt/libomp/lib:$DYLD_LIBRARY_PATH' >> $GITHUB_ENV
+
     - name: Install benchopt and its dependencies
       run: |
         conda info

--- a/.github/workflows/test_benchmarks.yml
+++ b/.github/workflows/test_benchmarks.yml
@@ -91,12 +91,6 @@ jobs:
         echo 'export CPPFLAGS="-I/usr/local/opt/libomp/include"' >> $GITHUB_ENV
         echo 'export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:/usr/local/opt/libomp/lib' >> $GITHUB_ENV
 
-    - name: Link libomp on macOS
-      if: matrix.os == 'macos-latest'
-      run: |
-        sudo ln -s /usr/local/opt/libomp/lib/libomp.dylib /usr/local/opt/libomp/lib/libomp.dylib
-
-
     - name: Install benchopt and its dependencies
       run: |
         conda info

--- a/.github/workflows/test_benchmarks.yml
+++ b/.github/workflows/test_benchmarks.yml
@@ -66,11 +66,17 @@ jobs:
 
     - run: conda info
 
-    - name: Install libomp on macOS
+    - name: Setup Rosetta (macOS only)
       if: matrix.os == 'macos-latest'
-      run: |
-        softwareupdate --install-rosetta --agree-to-license
-        arch -x86_64 /usr/local/bin/brew install llvm libomp
+      run: sudo softwareupdate --install-rosetta --agree-to-license
+
+    - name: Install Homebrew (macOS only)
+      if: matrix.os == 'macos-latest'
+      run: arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+    - name: Install libomp (macOS only)
+      if: matrix.os == 'macos-latest'
+      run: arch -x86_64 /usr/local/homebrew/bin/brew install libomp
 
     - name: Add libomp to path on macOS
       if: matrix.os == 'macos-latest'

--- a/.github/workflows/test_benchmarks.yml
+++ b/.github/workflows/test_benchmarks.yml
@@ -70,9 +70,19 @@ jobs:
       if: matrix.os == 'macos-latest'
       run: |
         brew install libomp
+
+    - name: Add libomp to path on macOS
+      if: matrix.os == 'macos-latest'
+      run: |
         echo 'export LDFLAGS="-L/opt/homebrew/opt/libomp/lib"' >> $GITHUB_ENV
         echo 'export CPPFLAGS="-I/opt/homebrew/opt/libomp/include"' >> $GITHUB_ENV
         echo 'export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:/opt/homebrew/opt/libomp/lib' >> $GITHUB_ENV
+        sudo mkdir -p /usr/local/opt/libomp/lib
+        sudo ln -s /opt/homebrew/opt/libomp/lib/libomp.dylib /usr/local/opt/libomp/lib/libomp.dylib
+
+    - name: Link libomp on macOS
+      if: matrix.os == 'macos-latest'
+      run: |
         sudo mkdir -p /usr/local/opt/libomp/lib
         sudo ln -s /opt/homebrew/opt/libomp/lib/libomp.dylib /usr/local/opt/libomp/lib/libomp.dylib
 

--- a/.github/workflows/test_benchmarks.yml
+++ b/.github/workflows/test_benchmarks.yml
@@ -94,7 +94,6 @@ jobs:
     - name: Link libomp on macOS
       if: matrix.os == 'macos-latest'
       run: |
-        sudo mkdir -p /usr/local/opt/libomp/lib
         sudo ln -s /usr/local/opt/libomp/lib/libomp.dylib /usr/local/opt/libomp/lib/libomp.dylib
 
 

--- a/.github/workflows/test_benchmarks.yml
+++ b/.github/workflows/test_benchmarks.yml
@@ -77,6 +77,10 @@ jobs:
         echo 'export LDFLAGS="-L/opt/homebrew/opt/libomp/lib"' >> $GITHUB_ENV
         echo 'export CPPFLAGS="-I/opt/homebrew/opt/libomp/include"' >> $GITHUB_ENV
         echo 'export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:/opt/homebrew/opt/libomp/lib' >> $GITHUB_ENV
+
+    - name: Link libomp on macOS
+      if: matrix.os == 'macos-latest'
+      run: |
         sudo mkdir -p /usr/local/opt/libomp/lib
         sudo ln -s /opt/homebrew/opt/libomp/lib/libomp.dylib /usr/local/opt/libomp/lib/libomp.dylib
 

--- a/.github/workflows/test_benchmarks.yml
+++ b/.github/workflows/test_benchmarks.yml
@@ -54,44 +54,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-
-    - name: Install Homebrew (macOS only)
-      if: matrix.os == 'macos-latest'
-      run: arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-
-    - name: Set up Homebrew environment (macOS only)
-      if: matrix.os == 'macos-latest'
-      run: |
-        if [ ! -d "/usr/local/share/info" ]; then
-            sudo mkdir -p /usr/local/share/info
-        fi
-        echo 'eval "$(/usr/local/bin/brew shellenv)"' >> /Users/runner/.bash_profile
-        eval "$(/usr/local/bin/brew shellenv)"
-        echo 'export PATH="/usr/local/opt/libomp/bin:$PATH"' >> $GITHUB_ENV
-        echo 'export LDFLAGS="-L/usr/local/opt/libomp/lib"' >> $GITHUB_ENV
-        echo 'export CPPFLAGS="-I/usr/local/opt/libomp/include"' >> $GITHUB_ENV
-
-    - name: Install libomp (macOS only)
-      if: matrix.os == 'macos-latest'
-      run: |
-        arch -x86_64 /usr/local/homebrew/bin/brew install libomp
-
-
-    - name: Set up environment variables for llvm (macOS only)
-      if: matrix.os == 'macos-latest'
-      run: |
-        echo 'export PATH="/opt/homebrew/opt/llvm/bin:$PATH"' >> $GITHUB_ENV
-        echo 'export LDFLAGS="-L/opt/homebrew/opt/llvm/lib -L/usr/local/opt/libomp/lib -L/opt/homebrew/opt/llvm/lib/c++ -Wl,-rpath,/opt/homebrew/opt/llvm/lib/c++"' >> $GITHUB_ENV
-        echo 'export CPPFLAGS="-I/opt/homebrew/opt/llvm/include -I/usr/local/opt/libomp/include"' >> $GITHUB_ENV
-        sudo mkdir -p /usr/local/opt/libomp/lib/
-        sudo ln -s /opt/homebrew/opt/libomp/lib/libomp.dylib /usr/local/opt/libomp/lib/libomp.dylib
-        echo 'export DYLD_LIBRARY_PATH="/usr/local/opt/libomp/lib:$DYLD_LIBRARY_PATH"' >> $GITHUB_ENV
-
-
-    - name: Source environment variables (macOS only)
-      if: matrix.os == 'macos-latest'
-      run: source $GITHUB_ENV
-
     - name: Setup Conda
       uses: conda-incubator/setup-miniconda@v2
       with:
@@ -103,6 +65,16 @@ jobs:
         activate-environment: ${{ env.CONDA_ENV }}
 
     - run: conda info
+
+    - name: Install libomp on macOS
+      if: matrix.os == 'macos-latest'
+      run: |
+        brew install libomp
+        echo 'export LDFLAGS="-L/opt/homebrew/opt/libomp/lib"' >> $GITHUB_ENV
+        echo 'export CPPFLAGS="-I/opt/homebrew/opt/libomp/include"' >> $GITHUB_ENV
+        echo 'export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:/opt/homebrew/opt/libomp/lib' >> $GITHUB_ENV
+        sudo mkdir -p /usr/local/opt/libomp/lib
+        sudo ln -s /opt/homebrew/opt/libomp/lib/libomp.dylib /usr/local/opt/libomp/lib/libomp.dylib
 
     - name: Install benchopt and its dependencies
       run: |

--- a/.github/workflows/test_benchmarks.yml
+++ b/.github/workflows/test_benchmarks.yml
@@ -73,6 +73,7 @@ jobs:
         brew install llvm
         echo 'export LDFLAGS="-L/opt/homebrew/opt/llvm/lib"' >> $GITHUB_ENV
         echo 'export CPPFLAGS="-I/opt/homebrew/opt/llvm/include"' >> $GITHUB_ENV
+        mkdir -p /usr/local/opt/libomp/lib
         ln -s /opt/homebrew/opt/llvm/lib/libomp.dylib /usr/local/opt/libomp/lib/libomp.dylib
 
     - name: Install benchopt and its dependencies

--- a/.github/workflows/test_benchmarks.yml
+++ b/.github/workflows/test_benchmarks.yml
@@ -74,22 +74,29 @@ jobs:
       if: matrix.os == 'macos-latest'
       run: arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
+    - name: Setup Homebrew environment (macOS only)
+      if: matrix.os == 'macos-latest'
+      run: |
+        echo 'eval "$(/usr/local/bin/brew shellenv)"' >> $HOME/.profile
+        eval "$(/usr/local/bin/brew shellenv)"
+
     - name: Install libomp (macOS only)
       if: matrix.os == 'macos-latest'
-      run: arch -x86_64 /usr/local/homebrew/bin/brew install libomp
+      run: arch -x86_64 /usr/local/bin/brew install libomp
 
     - name: Add libomp to path on macOS
       if: matrix.os == 'macos-latest'
       run: |
-        echo 'export LDFLAGS="-L/opt/homebrew/opt/libomp/lib"' >> $GITHUB_ENV
-        echo 'export CPPFLAGS="-I/opt/homebrew/opt/libomp/include"' >> $GITHUB_ENV
-        echo 'export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:/opt/homebrew/opt/libomp/lib' >> $GITHUB_ENV
+        echo 'export LDFLAGS="-L/usr/local/opt/libomp/lib"' >> $GITHUB_ENV
+        echo 'export CPPFLAGS="-I/usr/local/opt/libomp/include"' >> $GITHUB_ENV
+        echo 'export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:/usr/local/opt/libomp/lib' >> $GITHUB_ENV
 
     - name: Link libomp on macOS
       if: matrix.os == 'macos-latest'
       run: |
         sudo mkdir -p /usr/local/opt/libomp/lib
-        sudo ln -s /opt/homebrew/opt/libomp/lib/libomp.dylib /usr/local/opt/libomp/lib/libomp.dylib
+        sudo ln -s /usr/local/opt/libomp/lib/libomp.dylib /usr/local/opt/libomp/lib/libomp.dylib
+
 
     - name: Install benchopt and its dependencies
       run: |

--- a/.github/workflows/test_benchmarks.yml
+++ b/.github/workflows/test_benchmarks.yml
@@ -73,6 +73,8 @@ jobs:
         echo 'export LDFLAGS="-L/opt/homebrew/opt/libomp/lib"' >> $GITHUB_ENV
         echo 'export CPPFLAGS="-I/opt/homebrew/opt/libomp/include"' >> $GITHUB_ENV
         echo 'export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:/opt/homebrew/opt/libomp/lib' >> $GITHUB_ENV
+        sudo mkdir -p /usr/local/opt/libomp/lib
+        sudo ln -s /opt/homebrew/opt/libomp/lib/libomp.dylib /usr/local/opt/libomp/lib/libomp.dylib
 
     - name: Install benchopt and its dependencies
       run: |

--- a/.github/workflows/test_benchmarks.yml
+++ b/.github/workflows/test_benchmarks.yml
@@ -70,7 +70,9 @@ jobs:
       if: matrix.os == 'macos-latest'
       run: |
         brew install libomp
-        echo 'export DYLD_LIBRARY_PATH=/usr/local/opt/libomp/lib:$DYLD_LIBRARY_PATH' >> $GITHUB_ENV
+        echo 'export LDFLAGS="-L/opt/homebrew/opt/libomp/lib"' >> $GITHUB_ENV
+        echo 'export CPPFLAGS="-I/opt/homebrew/opt/libomp/include"' >> $GITHUB_ENV
+        echo 'export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:/opt/homebrew/opt/libomp/lib' >> $GITHUB_ENV
 
     - name: Install benchopt and its dependencies
       run: |
@@ -108,7 +110,6 @@ jobs:
           else
             echo "compatible"
             echo "compatible=true" >> $GITHUB_OUTPUT
-          fi
 
     - name: Test
       if: ${{ steps.check_min_version.outputs.compatible == 'true' }}

--- a/.github/workflows/test_benchmarks.yml
+++ b/.github/workflows/test_benchmarks.yml
@@ -80,12 +80,6 @@ jobs:
         sudo mkdir -p /usr/local/opt/libomp/lib
         sudo ln -s /opt/homebrew/opt/libomp/lib/libomp.dylib /usr/local/opt/libomp/lib/libomp.dylib
 
-    - name: Link libomp on macOS
-      if: matrix.os == 'macos-latest'
-      run: |
-        sudo mkdir -p /usr/local/opt/libomp/lib
-        sudo ln -s /opt/homebrew/opt/libomp/lib/libomp.dylib /usr/local/opt/libomp/lib/libomp.dylib
-
     - name: Install benchopt and its dependencies
       run: |
         conda info

--- a/.github/workflows/test_benchmarks.yml
+++ b/.github/workflows/test_benchmarks.yml
@@ -66,9 +66,10 @@ jobs:
 
     - run: conda info
 
-    - name: Add libomp to path on macOS
+    - name: install libomp on macOS
       if: matrix.os == 'macos-latest'
       run: |
+        arch -x86_64 /usr/local/bin/brew install libomp
         echo 'export LDFLAGS="-L/usr/local/opt/libomp/lib"' >> $GITHUB_ENV
         echo 'export CPPFLAGS="-I/usr/local/opt/libomp/include"' >> $GITHUB_ENV
         echo 'export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:/usr/local/opt/libomp/lib' >> $GITHUB_ENV

--- a/.github/workflows/test_benchmarks.yml
+++ b/.github/workflows/test_benchmarks.yml
@@ -69,18 +69,11 @@ jobs:
     - name: Install libomp on macOS
       if: matrix.os == 'macos-latest'
       run: |
-        # Install libomp from source for arm64 architecture
-        brew uninstall libomp  # Uninstall if already installed to ensure arm64 version is used
-        brew install libomp --build-from-source
-
-        # Set environment variables for libomp
-        echo 'export LDFLAGS="-L/opt/homebrew/opt/libomp/lib"' >> $GITHUB_ENV
-        echo 'export CPPFLAGS="-I/opt/homebrew/opt/libomp/include"' >> $GITHUB_ENV
-        echo 'export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:/opt/homebrew/opt/libomp/lib' >> $GITHUB_ENV
-
-        # Create necessary symlink (adjust path as needed)
-        sudo mkdir -p /usr/local/opt/libomp/lib
-        sudo ln -s /opt/homebrew/opt/libomp/lib/libomp.dylib /usr/local/opt/libomp/lib/libomp.dylib
+        brew update
+        brew install llvm
+        echo 'export LDFLAGS="-L/opt/homebrew/opt/llvm/lib"' >> $GITHUB_ENV
+        echo 'export CPPFLAGS="-I/opt/homebrew/opt/llvm/include"' >> $GITHUB_ENV
+        ln -s /opt/homebrew/opt/llvm/lib/libomp.dylib /usr/local/opt/libomp/lib/libomp.dylib
 
     - name: Install benchopt and its dependencies
       run: |

--- a/.github/workflows/test_benchmarks.yml
+++ b/.github/workflows/test_benchmarks.yml
@@ -69,7 +69,15 @@ jobs:
     - name: Install libomp on macOS
       if: matrix.os == 'macos-latest'
       run: |
-        brew install libomp
+        arch=$(uname -m)
+        if [[ "$arch" == "arm64" ]]; then
+          # Install llvm with x86_64 architecture using Rosetta
+          softwareupdate --install-rosetta --agree-to-license
+          arch -x86_64 /usr/local/homebrew/bin/brew install llvm
+          arch -x86_64 /usr/local/homebrew/bin/brew install libomp
+        else
+          brew install libomp
+        fi
 
     - name: Add libomp to path on macOS
       if: matrix.os == 'macos-latest'
@@ -82,7 +90,12 @@ jobs:
       if: matrix.os == 'macos-latest'
       run: |
         sudo mkdir -p /usr/local/opt/libomp/lib
-        sudo ln -s /opt/homebrew/opt/libomp/lib/libomp.dylib /usr/local/opt/libomp/lib/libomp.dylib
+        arch=$(uname -m)
+        if [[ "$arch" == "arm64" ]]; then
+          sudo ln -s /opt/homebrew/opt/libomp/lib/libomp.dylib /usr/local/opt/libomp/lib/libomp.dylib
+        else
+          sudo ln -s /usr/local/opt/libomp/lib/libomp.dylib /usr/local/opt/libomp/lib/libomp.dylib
+        fi
 
     - name: Install benchopt and its dependencies
       run: |

--- a/.github/workflows/test_benchmarks.yml
+++ b/.github/workflows/test_benchmarks.yml
@@ -66,6 +66,14 @@ jobs:
 
     - run: conda info
 
+    - name: Install and setup Homebrew on macOS
+      if: matrix.os == 'macos-latest'
+      run: |
+        arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+        echo 'eval "$(/usr/local/bin/brew shellenv)"' >> $HOME/.profile
+        eval "$(/usr/local/bin/brew shellenv)"
+
+
     - name: install libomp on macOS
       if: matrix.os == 'macos-latest'
       run: |

--- a/.github/workflows/test_benchmarks.yml
+++ b/.github/workflows/test_benchmarks.yml
@@ -70,8 +70,7 @@ jobs:
       if: matrix.os == 'macos-latest'
       run: |
         softwareupdate --install-rosetta --agree-to-license
-        arch -x86_64 /usr/local/homebrew/bin/brew install llvm
-        arch -x86_64 /usr/local/homebrew/bin/brew install libomp
+        arch -x86_64 /usr/local/bin/brew install llvm libomp
 
     - name: Add libomp to path on macOS
       if: matrix.os == 'macos-latest'

--- a/.github/workflows/test_benchmarks.yml
+++ b/.github/workflows/test_benchmarks.yml
@@ -69,15 +69,9 @@ jobs:
     - name: Install libomp on macOS
       if: matrix.os == 'macos-latest'
       run: |
-        arch=$(uname -m)
-        if [[ "$arch" == "arm64" ]]; then
-          # Install llvm with x86_64 architecture using Rosetta
-          softwareupdate --install-rosetta --agree-to-license
-          arch -x86_64 /usr/local/homebrew/bin/brew install llvm
-          arch -x86_64 /usr/local/homebrew/bin/brew install libomp
-        else
-          brew install libomp
-        fi
+        softwareupdate --install-rosetta --agree-to-license
+        arch -x86_64 /usr/local/homebrew/bin/brew install llvm
+        arch -x86_64 /usr/local/homebrew/bin/brew install libomp
 
     - name: Add libomp to path on macOS
       if: matrix.os == 'macos-latest'
@@ -90,12 +84,7 @@ jobs:
       if: matrix.os == 'macos-latest'
       run: |
         sudo mkdir -p /usr/local/opt/libomp/lib
-        arch=$(uname -m)
-        if [[ "$arch" == "arm64" ]]; then
-          sudo ln -s /opt/homebrew/opt/libomp/lib/libomp.dylib /usr/local/opt/libomp/lib/libomp.dylib
-        else
-          sudo ln -s /usr/local/opt/libomp/lib/libomp.dylib /usr/local/opt/libomp/lib/libomp.dylib
-        fi
+        sudo ln -s /opt/homebrew/opt/libomp/lib/libomp.dylib /usr/local/opt/libomp/lib/libomp.dylib
 
     - name: Install benchopt and its dependencies
       run: |

--- a/.github/workflows/test_benchmarks.yml
+++ b/.github/workflows/test_benchmarks.yml
@@ -110,6 +110,7 @@ jobs:
           else
             echo "compatible"
             echo "compatible=true" >> $GITHUB_OUTPUT
+          fi
 
     - name: Test
       if: ${{ steps.check_min_version.outputs.compatible == 'true' }}

--- a/.github/workflows/test_benchmarks.yml
+++ b/.github/workflows/test_benchmarks.yml
@@ -62,6 +62,9 @@ jobs:
     - name: Set up Homebrew environment (macOS only)
       if: matrix.os == 'macos-latest'
       run: |
+        if [ ! -d "/usr/local/share/info" ]; then
+            sudo mkdir -p /usr/local/share/info
+        fi
         echo 'eval "$(/usr/local/bin/brew shellenv)"' >> /Users/runner/.bash_profile
         eval "$(/usr/local/bin/brew shellenv)"
         echo 'export PATH="/usr/local/opt/libomp/bin:$PATH"' >> $GITHUB_ENV
@@ -72,7 +75,6 @@ jobs:
       if: matrix.os == 'macos-latest'
       run: |
         arch -x86_64 /usr/local/homebrew/bin/brew install libomp
-        echo 'export DYLD_LIBRARY_PATH="/usr/local/opt/libomp/lib:$DYLD_LIBRARY_PATH"' >> $GITHUB_ENV
 
 
     - name: Set up environment variables for llvm (macOS only)
@@ -81,6 +83,10 @@ jobs:
         echo 'export PATH="/opt/homebrew/opt/llvm/bin:$PATH"' >> $GITHUB_ENV
         echo 'export LDFLAGS="-L/opt/homebrew/opt/llvm/lib -L/usr/local/opt/libomp/lib -L/opt/homebrew/opt/llvm/lib/c++ -Wl,-rpath,/opt/homebrew/opt/llvm/lib/c++"' >> $GITHUB_ENV
         echo 'export CPPFLAGS="-I/opt/homebrew/opt/llvm/include -I/usr/local/opt/libomp/include"' >> $GITHUB_ENV
+        sudo mkdir -p /usr/local/opt/libomp/lib/
+        sudo ln -s /opt/homebrew/opt/libomp/lib/libomp.dylib /usr/local/opt/libomp/lib/libomp.dylib
+        echo 'export DYLD_LIBRARY_PATH="/usr/local/opt/libomp/lib:$DYLD_LIBRARY_PATH"' >> $GITHUB_ENV
+
 
     - name: Source environment variables (macOS only)
       if: matrix.os == 'macos-latest'


### PR DESCRIPTION
`libomp x86_64` is needed for snapML on macOS. Homebrew is needed for this install as well.
This helps solve the following error in CI : [link](https://github.com/benchopt/benchmark_ridge/actions/runs/9777672033/job/26992852848#step:7:494) .

A few precisions : 

- Homebrew is needed to install `libomp x86_64`. And the following commands are a suggestion from documentation to set up Homebrew : 

```
Run these two commands in your terminal to add Homebrew to your PATH:

(echo; echo 'eval "$(/usr/local/bin/brew shellenv)"') >> /Users/runner/.bash_profile

eval "$(/usr/local/bin/brew shellenv)"
```
- Also, libomp needs some directories added to `PATH` to function correctly. documentation says : 

```
libomp is keg-only, which means it was not symlinked into /usr/local,

because it can override GCC headers and result in broken builds.

For compilers to find libomp you may need to set:

export LDFLAGS="-L/usr/local/opt/libomp/lib"

export CPPFLAGS="-I/usr/local/opt/libomp/include"
```

