### PR TITLE
MTN update setup-miniconda action

### DIFF
--- a/.github/workflows/test_benchmarks.yml
+++ b/.github/workflows/test_benchmarks.yml
@@ -17,7 +17,7 @@ on:
         type: string
       python_version:
         description: Python version to use for the tests.
-        default: "3.9"
+        default: "3.10"
         required: false
         type: string
       extra_args:
@@ -58,12 +58,13 @@ jobs:
         shell: bash -l {0}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup Conda
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v3
       with:
         auto-update-conda: true
-        miniforge-variant: Mambaforge
+        miniforge-version: latest
+        mamba-version: "*"
         use-mamba: true
         channels: conda-forge
         python-version: ${{ inputs.python_version }}


### PR DESCRIPTION
Mambaforge, that we were using in our GH actions, [is sunsetting](https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/).
This PR update the workflow to use the novel version of `setup-miniforge` and [still setup mamba](https://github.com/conda-incubator/setup-miniconda).