### PR TITLE
FIX use conda for latest release

### DIFF
--- a/.github/workflows/test_benchmarks.yml
+++ b/.github/workflows/test_benchmarks.yml
@@ -52,7 +52,8 @@ jobs:
       BENCHOPT_VERSION: ${{ inputs.benchopt_version }}
       PYTEST_EXTRA_ARGS: ${{ inputs.extra_args }}
       BENCHOPT_DEBUG: 1
-      BENCHOPT_CONDA_CMD: mamba
+      #TODO: Use mamba again once benchopt 1.6 is out.
+      BENCHOPT_CONDA_CMD: ${{ inputs.benchopt_version == 'latest' && 'conda' || 'mamba' }}
 
     concurrency:
       group: ${{ github.workflow }}-${{ github.job }}-${{ matrix.os }}-${{ inputs.benchopt_version }}-${{ inputs.extra_args }}-${{ github.ref }}


### PR DESCRIPTION
Closes #43 

This is a temporary fix to mitigate the fact that the current benchopt release uses `--update-all` even when mamba is used as the conda cmd, which fails since there is no `--update-all` flag for mamba. See #43 for more info.