### PR TITLE
Fix: Lipschitz normalization in GD + ordinary least-squares cost functions

### DIFF
--- a/benchmark_utils/__init__.py
+++ b/benchmark_utils/__init__.py
@@ -10,4 +10,4 @@ def gradient_ols(X, y, beta):
 
 
 def value_ols(X, y, beta):
-    return 0.5 * np.mean((y - X @ beta) ** 2)
+    return 0.5 * np.linalg.vector_norm((y - X @ beta) ** 2)

--- a/solvers/python-gd.py
+++ b/solvers/python-gd.py
@@ -53,8 +53,9 @@ class Solver(BaseSolver):
         # See https://benchopt.github.io/guide/auto_stop.html for more details.
 
         self.beta = np.zeros(self.X.shape[1])
+        L = np.linalg.norm(self.X, ord=2)**2
         while callback():
-            self.beta -= self.learning_rate * gradient_ols(
+            self.beta -= (self.learning_rate / L) * gradient_ols(
                 self.X, self.y, self.beta
             )
 


### PR DESCRIPTION
This PR addresses issue https://github.com/benchopt/template_benchmark/issues/49 

**proposed changes**
1. update of run() method by normalizing steps with the Lipschitz constant
2.  update of the computation of the objective value_ols() to match the gradient definition

I can remove point 2) if not relevant.

Thanks!